### PR TITLE
Allow further control of the deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ You can set the following values:
 | `labels`                          | Additional labels. Defaults to `{}`
 | `environment`                     | Additional environment variables. Defaults to `{}`
 | `enableServiceLinks`              | Indicates whether information about services should be injected into pod's environment variables. Defaults to `true`
+| `useDefaultServiceAccount`        | Indicates whether the `default` ServiceAccount should be used. Otherwise a ServiceAccount with the name `gitbucket.fullname` will be created. Defaults to `true`
 
 
 ## External database

--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ You can set the following values:
 | `resources.requests.memory`       | Memory request. Defaults to `1Gi`.
 | `ingress.enabled`                 | If true, an ingress is be created.
 | `ingress.hosts`                   | A list of hosts for the ingress.
+| `annotations`                     | Additional annotations. Defaults to `{}`
+| `labels`                          | Additional labels. Defaults to `{}`
+| `environment`                     | Additional environment variables. Defaults to `{}`
+| `enableServiceLinks`              | Indicates whether information about services should be injected into pod's environment variables. Defaults to `true`
 
 
 ## External database

--- a/charts/gitbucket/templates/deployment.yaml
+++ b/charts/gitbucket/templates/deployment.yaml
@@ -30,7 +30,9 @@ spec:
       {{- end }}
       {{- end }}
     spec:
+      {{- if not .Values.useDefaultServiceAccount }}
       serviceAccountName: {{ template "gitbucket.fullname" . }}
+      {{- end }}
       {{- if not .Values.enableServiceLinks }}
       enableServiceLinks: false
       {{- end }}

--- a/charts/gitbucket/templates/deployment.yaml
+++ b/charts/gitbucket/templates/deployment.yaml
@@ -15,10 +15,25 @@ spec:
       release: {{ .Release.Name }}
   template:
     metadata:
+      {{- if .Values.annotations }}
+      annotations:
+      {{- range $key, $value := .Values.annotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+      {{- end }}
       labels:
         app: {{ template "gitbucket.name" . }}
         release: {{ .Release.Name }}
+      {{- if .Values.labels }}
+      {{- range $key, $value := .Values.labels }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+      {{- end }}
     spec:
+      serviceAccountName: {{ template "gitbucket.fullname" . }}
+      {{- if not .Values.enableServiceLinks }}
+      enableServiceLinks: false
+      {{- end }}
       initContainers:
         - name: chown-data-volume
           image: alpine
@@ -72,6 +87,12 @@ spec:
             - name: GITBUCKET_OPTS
               value: {{ .Values.gitbucket.options }}
 {{- end }}
+            {{- if .Values.environment }}
+            {{- range $key, $val := .Values.environment }}
+            - name: {{ $key | upper }}
+              value: {{ $val | quote }}
+            {{- end }}
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /signin

--- a/charts/gitbucket/templates/secret.yaml
+++ b/charts/gitbucket/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.externalDatabase.password }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,6 +10,5 @@ metadata:
     heritage: {{ .Release.Service }}
 type: Opaque
 data:
-{{- if .Values.externalDatabase.password }}
   externalDatabasePassword: {{ .Values.externalDatabase.password | b64enc | quote }}
 {{- end }}

--- a/charts/gitbucket/templates/serviceaccount.yaml
+++ b/charts/gitbucket/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.useDefaultServiceAccount }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -9,3 +10,4 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}

--- a/charts/gitbucket/templates/serviceaccount.yaml
+++ b/charts/gitbucket/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "gitbucket.fullname" $ }}
+  labels:
+    # standard labels: https://helm.sh/docs/topics/chart_best_practices/labels/#standard-labels
+    app.kubernetes.io/name: {{ template "gitbucket.fullname" . }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}

--- a/charts/gitbucket/values.yaml
+++ b/charts/gitbucket/values.yaml
@@ -67,3 +67,15 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# kubernetes may inject environment variables that clash with gitbucket,
+enableServiceLinks: true
+
+# add meta annotations
+annotations: {}
+
+# add meta labels
+labels: {}
+
+# add extra environment variables
+environment: {}

--- a/charts/gitbucket/values.yaml
+++ b/charts/gitbucket/values.yaml
@@ -79,3 +79,6 @@ labels: {}
 
 # add extra environment variables
 environment: {}
+
+# do not create the service with name `gitbucket.fullname` nor set the serviceAccountName in the deployment
+useDefaultServiceAccount: true


### PR DESCRIPTION
I extended the chart so it's possible to configure annotation, labels and environment for the gitbucket container.

Added functionality to set the `enableServiceLinks` to false as the newer gitbucket attempts to read `GITBUCKET_PORT` which may, depending on your deployment, be set by kubernetes to something that gitbucket cannot parse as an int.

Also added functionality to create a named ServiceAccount but the default behavior is still to use the `default`