### PR TITLE
Improve compliance and configuration of security aspects

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk-alpine
+FROM azul/zulu-openjdk-alpine:8
 
 # ttf-dejavu: Fix NPE on font rendering https://github.com/docker-library/openjdk/issues/73
 RUN apk add --no-cache git curl bash ttf-dejavu
@@ -23,7 +23,7 @@ EXPOSE 8080
 EXPOSE 29418
 
 # Run as dedicated user
-USER gitbucket
+USER 1000
 
 # Configure heap memory by cgroup memory limit
 # https://blogs.oracle.com/java-platform-group/java-se-support-for-docker-cpu-and-memory-limits

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ You can set the following values:
 | `environment`                     | Additional environment variables. Defaults to `{}`
 | `enableServiceLinks`              | Indicates whether information about services should be injected into pod's environment variables. Defaults to `true`
 | `useDefaultServiceAccount`        | Indicates whether the `default` ServiceAccount should be used. Otherwise a ServiceAccount with the name `gitbucket.fullname` will be created. Defaults to `true`
+| `runAsNonRoot`                    | Require that the container will run with a user with any UID other than 0. Defaults to `false`
+| `chownDataDirectoryInInitContainer` | Enable initContainer that will change ownership of data directory to 1000:1000. Defaults to `true`
 
 
 ## External database

--- a/charts/gitbucket/templates/deployment.yaml
+++ b/charts/gitbucket/templates/deployment.yaml
@@ -36,6 +36,12 @@ spec:
       {{- if not .Values.enableServiceLinks }}
       enableServiceLinks: false
       {{- end }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range $pullSecret := .Values.image.pullSecrets }}
+      - name: {{ $pullSecret }}
+      {{- end }}
+      {{- end }}
       initContainers:
         - name: chown-data-volume
           image: alpine

--- a/charts/gitbucket/templates/deployment.yaml
+++ b/charts/gitbucket/templates/deployment.yaml
@@ -42,6 +42,7 @@ spec:
       - name: {{ $pullSecret }}
       {{- end }}
       {{- end }}
+      {{- if .Values.chownDataDirectoryInInitContainer }}
       initContainers:
         - name: chown-data-volume
           image: alpine
@@ -50,8 +51,11 @@ spec:
           volumeMounts:
           - name: data-volume
             mountPath: /var/gitbucket
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
+          securityContext:
+            runAsNonRoot: {{ .Values.runAsNonRoot }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:

--- a/charts/gitbucket/values.yaml
+++ b/charts/gitbucket/values.yaml
@@ -84,3 +84,9 @@ environment: {}
 
 # do not create the service with name `gitbucket.fullname` nor set the serviceAccountName in the deployment
 useDefaultServiceAccount: true
+
+# change ownership of data directory to 1000:1000 using initContainer
+chownDataDirectoryInInitContainer: true
+
+# require that the container will run with a user with any UID other than 0
+runAsNonRoot: false

--- a/charts/gitbucket/values.yaml
+++ b/charts/gitbucket/values.yaml
@@ -3,6 +3,8 @@
 image:
   repository: int128/gitbucket
   tag: "4.34.0"
+  # Pull secrets used for accessing image repositories
+  pullSecrets: []
   # pullPolicy: IfNotPresent
 
 gitbucket:


### PR DESCRIPTION
Various modification to improve compliance and security as polaris and clair weren't too happy:

- Support image pull secrets
- Replace base docker image to azul/zulu-openjpk-alpine
- Use numeric USER
- Allow setting securityContext.runAsNonRoot
- Allow skipping chown-data-volume initContainer
