### PR TITLE
Ability to deploy helm chart in k8s > 1.16

### DIFF
--- a/charts/gitbucket/templates/deployment.yaml
+++ b/charts/gitbucket/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "gitbucket.fullname" . }}


### PR DESCRIPTION
Kubernetes deprecated this apiVersion apps/v1beta2 in k8s 1.16, this change will work backwards until k8s 1.9, where the apps/v1 api was introduced.